### PR TITLE
fix about headline typo

### DIFF
--- a/src/about/readme.md
+++ b/src/about/readme.md
@@ -1,5 +1,5 @@
 ---
-title: We are group
+title: We are a group
 image: /img/img-about.jpg
 ---
 


### PR DESCRIPTION
"We are group" -> "We are **a** group" in About